### PR TITLE
Fix DeviceCodeFlow usage

### DIFF
--- a/HOWTOUSE.txt
+++ b/HOWTOUSE.txt
@@ -1,0 +1,4 @@
+I've installed earthscope-cli, so to make sure I'm logged in on this devide I just need to do this:
+- in cmd: es login
+- follow procedure
+Then, code can be executed

--- a/HOWTOUSE.txt
+++ b/HOWTOUSE.txt
@@ -1,4 +1,0 @@
-I've installed earthscope-cli, so to make sure I'm logged in on this devide I just need to do this:
-- in cmd: es login
-- follow procedure
-Then, code can be executed


### PR DESCRIPTION
EarthScope has been updated (SDK v1 implementation) and gdoper didn't work anymore. This commit updates earthscope.py to fix errors arising from DeviceCodeFlow (previously DeviceCodeFlowSimple) usage.
Running gdoper.py works again.